### PR TITLE
feat: add support for an omitEmitField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for the `omitEmitField` option in the `generateCodecCode` method. When specified, schemas having a truthy value in the field indicated by the `omitEmitField` value will not be added to the type emit.
 
 ## [0.7.0-0] - 2022-05-20
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ajv-formats": "^2.0.2",
         "esbuild-wasm": "^0.11.6",
         "fast-glob": "^3.2.5",
-        "json-schema-to-dts": "^1.4.1",
+        "json-schema-to-dts": "^1.5.0",
         "prettier": "^2.2.1",
         "resolve": "^1.20.0",
         "typescript": "^4.1.3"
@@ -4515,9 +4515,9 @@
       "dev": true
     },
     "node_modules/json-schema-to-dts": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-dts/-/json-schema-to-dts-1.4.1.tgz",
-      "integrity": "sha512-YdRLGFY0AN+7incVCjYJPbERm8XuySYMtGDXLo/E8dHUIaVUFpIji+XKEB6ctGwgQzfhWXrB0+8I1dC/OHaWdA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/json-schema-to-dts/-/json-schema-to-dts-1.5.0.tgz",
+      "integrity": "sha512-5jBTjNwcoNTgsjtlSFdxl9XHSyhXQ0qITvtxfjiDYKN5PVsww9Z5AUwmJeazGvHqQECoWYQQufLFhJsYdzns+Q==",
       "dependencies": {
         "ts-morph": "^8.1.1"
       },
@@ -10339,9 +10339,9 @@
       "dev": true
     },
     "json-schema-to-dts": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-dts/-/json-schema-to-dts-1.4.1.tgz",
-      "integrity": "sha512-YdRLGFY0AN+7incVCjYJPbERm8XuySYMtGDXLo/E8dHUIaVUFpIji+XKEB6ctGwgQzfhWXrB0+8I1dC/OHaWdA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/json-schema-to-dts/-/json-schema-to-dts-1.5.0.tgz",
+      "integrity": "sha512-5jBTjNwcoNTgsjtlSFdxl9XHSyhXQ0qITvtxfjiDYKN5PVsww9Z5AUwmJeazGvHqQECoWYQQufLFhJsYdzns+Q==",
       "requires": {
         "ts-morph": "^8.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ajv-formats": "^2.0.2",
     "esbuild-wasm": "^0.11.6",
     "fast-glob": "^3.2.5",
-    "json-schema-to-dts": "^1.4.1",
+    "json-schema-to-dts": "^1.5.0",
     "prettier": "^2.2.1",
     "resolve": "^1.20.0",
     "typescript": "^4.1.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,12 @@ export interface GenerateCodecCodeOptions {
   externalizeValidatorLibrary?: boolean;
   validateFormats?: boolean;
   moduleFormat?: Esbuild.Format;
+
+  /**
+   * Schema field that, when truthy, will result in the sub-schema being omitted
+   * in the generated types.
+   */
+  omitEmitField?: `x-${string}`;
 }
 
 export interface GenerateResult {
@@ -121,6 +127,22 @@ export async function generateCodecCode(
     // Skip emitting reference comments
     omitIdComments: true,
 
+    shouldOmitTypeEmit(node) {
+      const omitField = options?.omitEmitField;
+
+      if (!omitField) {
+        // Always emit if we don't have a special field configured;
+        return true;
+      }
+
+      if (typeof node.schema !== 'object' && node.schema != null) {
+        // Always emit for boolean (and other?) schemas since we can't
+        // have user-defined properties of non-object and null schemas.
+        return true;
+      }
+
+      return !node.schema[omitField];
+    }
   });
 
   if (diagnostics.length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,9 @@ export async function generateCodecCode(
       isExported: true,
     },
     anyType: options.anyType ?? 'JSONValue',
+    // Skip emitting reference comments
+    omitIdComments: true,
+
   });
 
   if (diagnostics.length) {

--- a/test/__snapshots__/index.ts.snap
+++ b/test/__snapshots__/index.ts.snap
@@ -305,23 +305,17 @@ export namespace Types {
    * A User Object
    *
    * A user is a known visitor.
-   * @see file:///User.json
    */
   export type User = {
-      id: string;
-      name: string;
+      [property: string]: JSONValue;
   };
   /**
    * A Blog Post
    *
    * A blog post represents an article associated with an author
-   * @see file:///BlogPost.json
    */
   export type BlogPost = {
-      id: string;
-      title: string;
-      content: string;
-      author?: User;
+      [property: string]: JSONValue;
   };
   
 }
@@ -735,14 +729,9 @@ export namespace Types {
   type JSONValue = JSONPrimitive | JSONValue[] | {
       [key: string]: JSONValue;
   };
-  /**
-   * A Bookmark
-   * @see file:///Bookmark.json
-   */
+  /** A Bookmark */
   export type Bookmark = {
-      url: string;
-      name: string;
-      added_at: string;
+      [property: string]: JSONValue;
   };
   
 }


### PR DESCRIPTION
## Description

Add support for the `omitEmitField` option so that schema authors can indicate that some sub-schemas should be hidden from emitted types.