### PR TITLE
fix: Correct opposite bools on omitEmitField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes inverted negation when supplying an `omitEmitField` option.
 
 ## [0.7.0] - 2022-08-31
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,16 +132,16 @@ export async function generateCodecCode(
 
       if (!omitField) {
         // Always emit if we don't have a special field configured;
-        return true;
+        return false;
       }
 
       if (typeof node.schema !== 'object' && node.schema != null) {
         // Always emit for boolean (and other?) schemas since we can't
         // have user-defined properties of non-object and null schemas.
-        return true;
+        return false;
       }
 
-      return !node.schema[omitField];
+      return !!node.schema[omitField];
     }
   });
 

--- a/test/__snapshots__/index.ts.snap
+++ b/test/__snapshots__/index.ts.snap
@@ -307,7 +307,8 @@ export namespace Types {
    * A user is a known visitor.
    */
   export type User = {
-      [property: string]: JSONValue;
+      id: string;
+      name: string;
   };
   /**
    * A Blog Post
@@ -315,7 +316,10 @@ export namespace Types {
    * A blog post represents an article associated with an author
    */
   export type BlogPost = {
-      [property: string]: JSONValue;
+      id: string;
+      title: string;
+      content: string;
+      author?: User;
   };
   
 }
@@ -731,7 +735,9 @@ export namespace Types {
   };
   /** A Bookmark */
   export type Bookmark = {
-      [property: string]: JSONValue;
+      url: string;
+      name: string;
+      added_at: string;
   };
   
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where the `omitEmitField` option was having the opposite effect as intended; sub-schemas _without_ the field were being omitted instead of included.